### PR TITLE
Fixing async error swallowing

### DIFF
--- a/source/server.js
+++ b/source/server.js
@@ -53,5 +53,14 @@ export default function server(webpack_configuration, settings)
 		}
 
 		throw new Error(`[universal-webpack] Your server source file must export a function`)
-	})
+	}).catch(function(err)
+  {
+    // bright red color
+    console.log("\x1b[1m\x1b[31m")
+    
+    console.error(`\n${err.stack}`)
+    
+    // reset color and brightness
+    console.log('\x1b[39m\x1b[22m')
+  })
 }


### PR DESCRIPTION
You can read about ES6 error swallowing [here](http://jamesknelson.com/are-es6-promises-swallowing-your-errors/).

I've encountered this, while using the package. Runtime errors which aren't detected in webpack build, cause the server run to fail without displaying any errors.
This is caused by the promise of `wait-for-file` in `server.js`. Adding a catch cb easily fixes this, mine just prints the error stack to stderr.