### PR TITLE
Ensure webpack-chunks.json is properly resolved.

### DIFF
--- a/source/chunks.js
+++ b/source/chunks.js
@@ -2,5 +2,9 @@ import path from 'path'
 
 export function chunk_info_file_path(webpack_configuration, chunk_info_filename)
 {
-	return path.join(webpack_configuration.output.path, chunk_info_filename || 'webpack-chunks.json')
+	return path.resolve(
+		webpack_configuration.context || process.cwd(),
+		webpack_configuration.output.path,
+		chunk_info_filename || 'webpack-chunks.json'
+	)
 }


### PR DESCRIPTION
A reference to the webpack context dir was missing in the chunk_info_file_path causing `Error: Cannot find module 'build/assets/webpack-chunks.json'` in some cases (my webpack files are not in the root of the project).

This should ensure the path is always properly resolved.