### PR TITLE
filename on Windows contains posix path separators

### DIFF
--- a/source/babel-register.js
+++ b/source/babel-register.js
@@ -1,6 +1,6 @@
 import path from 'path'
 
-const node_modules = `${path.sep}node_modules${path.sep}`
+const node_modules = `${path.posix.sep}node_modules${path.posix.sep}`
 
 // Exclude `node_modules` anywhere in the path,
 // and also the server-side bundle output by `universal-webpack`.


### PR DESCRIPTION
That is why on Windows files from node_modules didn't ignored by
babel-register.