### PR TITLE
Fix find_style_rules for extract-text-webpack-plugin 3.0

### DIFF
--- a/source/loaders.js
+++ b/source/loaders.js
@@ -22,7 +22,7 @@ export function find_style_rules(configuration)
 		const style_loader = rule.use.filter( loader_name_filter( 'style' ) )[0]
 
 		// Is it `extract-text-webpack-plugin` loader
-		const extract_text_plugin_loader = rule.use.filter( loader => loader.loader.indexOf( 'extract-text-webpack-plugin/loader.js' ) >= 0 )[0]
+		const extract_text_plugin_loader = rule.use.filter( loader => /extract-text-webpack-plugin/.test(loader.loader) )[0]
 
 		return style_loader && !extract_text_plugin_loader
 	} )


### PR DESCRIPTION
Since extract-text-webpack-plugin 3.0, loader path has changed to
"extract-text-webpack-plugin/dist/loader.js", it breaks current check
algorithm.