### PR TITLE
add support for css-loader v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,10 @@ const configuration = clientConfiguration(baseConfiguration, settings, {
 
 `css-loader@3` [renamed](https://github.com/catamphetamine/universal-webpack/issues/109) `exportOnlyLocals` option to `onlyLocals`. To switch this library into `css-loader@3`-compatible mode set `UNIVERSAL_WEBPACK_CSS_LOADER_V3` environment variable to `true`.
 
+## CSS loader v4
+
+`css-loader@4` [moved](https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#400-2020-07-25) `onlyLocals` option into `modules` as `exportOnlyLocals`. To switch this library into `css-loader@4`-compatible mode set `UNIVERSAL_WEBPACK_CSS_LOADER_V4` environment variable to `true`.
+
 ## Advanced configuration
 
 `./universal-webpack-settings.json` configuration file also supports the following optional configuration parameters:

--- a/source/server configuration.js
+++ b/source/server configuration.js
@@ -327,7 +327,25 @@ export function replace_style_loader(configuration)
 			// Replace `css-loader` with `css-loader/locals`.
 			// Also there's a stupid difference between `css-loader@2` and `css-loader@1`:
 			// https://github.com/catamphetamine/universal-webpack/issues/101
-			if (process.env.UNIVERSAL_WEBPACK_CSS_LOADER_V3) {
+			if (process.env.UNIVERSAL_WEBPACK_CSS_LOADER_V4) {
+				// First standardize on object shape. `modules` can be a boolean or a
+				// string, but if it's falsey, it means modules aren't even enabled.
+				if (css_loader.options.modules) {
+					if (css_loader.options.modules === true) {
+						css_loader.options.modules = { modules: "local" };
+					} else if (typeof css_loader.options.modules === "string") {
+						css_loader.options.modules = { mode: css_loader.options.modules };
+					}
+					const modules = css_loader.options.modules;
+				css_loader.options = {
+					...css_loader.options,
+						modules: {
+							...modules,
+							exportOnlyLocals: true,
+						},
+					};
+				}
+			} else if (process.env.UNIVERSAL_WEBPACK_CSS_LOADER_V3) {
 				css_loader.options = {
 					...css_loader.options,
 					onlyLocals: true

--- a/source/server configuration.js
+++ b/source/server configuration.js
@@ -331,12 +331,12 @@ export function replace_style_loader(configuration)
 				// First standardize on object shape. `modules` can be a boolean or a
 				// string, but if it's falsey, it means modules aren't even enabled.
 				if (css_loader.options.modules) {
+					let modules = css_loader.options.modules;
 					if (css_loader.options.modules === true) {
-						css_loader.options.modules = { modules: "local" };
+						modules = { modules: "local" };
 					} else if (typeof css_loader.options.modules === "string") {
-						css_loader.options.modules = { mode: css_loader.options.modules };
+						modules = { mode: css_loader.options.modules };
 					}
-					const modules = css_loader.options.modules;
 				css_loader.options = {
 					...css_loader.options,
 						modules: {


### PR DESCRIPTION
continuing in the tradition of using these environment variables to set the version, to track changes to `css-loader`'s configuration